### PR TITLE
Added support for more recent version of tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y install bison flex cmake git xdg-utils \
   libusb-1.0-0-dev libserialport-dev libavahi-client-dev \
   libavahi-common-dev libgtk2.0-dev libgtkdatabox-dev \
   libmatio-dev libfftw3-dev libcurl4-openssl-dev \
-  libjansson-dev
+  libjansson-dev libcanberra-gtk-module packagekit-gtk3-module
 
 # Install libiio
 RUN ./install_libiio.sh


### PR DESCRIPTION
These two packages are now required for the latest version of iio oscilloscope to run correctly within the container.